### PR TITLE
make roles not have a race condition startup error. 

### DIFF
--- a/modules/roles.js
+++ b/modules/roles.js
@@ -217,7 +217,7 @@ Module.addInteraction({
     }
   }
 })
-.setInit(() => {
+.addEvent("ready", () => {
   setRoles();
 })
 .addEvent("guildMemberUpdate", async (oldMember, newMember) => {


### PR DESCRIPTION
ready triggers when ready, init triggers when loaded. this caused an error because login-requiring stuff was accessed and required in init, but only sometimes if the login command took longer than it took for it to get to the init function in the module.