### PR TITLE
Potential fix for code scanning alerts

### DIFF
--- a/modules/fun.js
+++ b/modules/fun.js
@@ -358,7 +358,7 @@ async function slashFunNamegame(int) {
     const song = /<blockquote>\n(.*)<\/blockquote>/g.exec(response?.data)?.[1]?.replace(/<br ?\/>/g, "\n");
     // make sure its safe
     const pf = new profanityFilter();
-    const profane = pf.scan(song?.toLowerCase().replace("\n", " ")).length;
+    const profane = pf.scan(song?.toLowerCase().replace(/\n/g, " ")).length;
     if (!song) {
       return int.editReply("I uh... broke my voice box. Try a different name?").then(u.clean);
     } else if (profane > 0) {

--- a/modules/site.js
+++ b/modules/site.js
@@ -31,7 +31,7 @@ if (config.siteOn) {
   // token storage setup
   app.use(session({
     secret: siteConfig.sessionSecret,
-    cookie: { 
+    cookie: {
       maxAge: 60000 * 60 * 24 * 3,
       secure: true,
       httpOnly: true

--- a/modules/site.js
+++ b/modules/site.js
@@ -31,7 +31,11 @@ if (config.siteOn) {
   // token storage setup
   app.use(session({
     secret: siteConfig.sessionSecret,
-    cookie: { maxAge: 60000 * 60 * 24 * 3 },
+    cookie: { 
+      maxAge: 60000 * 60 * 24 * 3,
+      secure: true,
+      httpOnly: true
+    },
     resave: false,
     saveUninitialized: false,
     store: Store.create({


### PR DESCRIPTION
Potential fix for [https://github.com/LDS-Gamers-Studios/icarus5.5/security/code-scanning/3](https://github.com/LDS-Gamers-Studios/icarus5.5/security/code-scanning/3)

Used a global regex instead of a string in `string.replace`. not the end of the world but we should probably do it just in case
also fixes a potential security flaw in the website backend